### PR TITLE
🔧 APIサーバーのポートを3055に変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -223,6 +225,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@ worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch('PORT', 3000)
+port ENV.fetch('PORT', 3055)
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   db:
     image: postgres:14.6
@@ -8,12 +8,12 @@ services:
       - db:/var/lib/postgresql/data
   api:
     build: .
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: bundle exec rails s -p 3055 -b '0.0.0.0'
     volumes:
       - .:/myapp
       - bundle:/usr/local/bundle
     ports:
-      - "3000:3000"
+      - "3055:3055"
     depends_on:
       - db
 volumes:


### PR DESCRIPTION
- docker-compose.ymlのポートマッピングを3055:3055に更新
- puma.rbのデフォルトポートを3055に設定

## 課題のリンク

* https://example.com

## やったこと

* このプルリクで何をしたのか？


## 動作確認方法

* 動作確認方法の手順を書いてください

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
